### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ LOCAL_IMAGE = ${IMAGE_NAME}
 # 1. User-provided, e.g., SUBMISSION_IMAGE=my-image:gpu-local make test-submission
 # 2. Local image, e.g., nasapushback-competition:gpu-local
 # 3. Official competition image, e.g., nasapushback.azurecr.io/nasapushback-competition
-SUBMISSION_IMAGE ?= ${LOCAL_IMAGE}:${TAG}
+SUBMISSION_IMAGE ?= ${LOCAL_IMAGE}:${LOCAL_TAG}
 ifeq (,$(shell docker images -q ${SUBMISSION_IMAGE}))
 SUBMISSION_IMAGE = ${OFFICIAL_IMAGE}:${TAG}
 endif

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,6 @@ ifeq (,${SUBMISSION_IMAGE_ID})
 	@echo
 else
 	@echo "$$(tput bold)Using image:$$(tput sgr0) ${SUBMISSION_IMAGE} (${SUBMISSION_IMAGE_ID})"
-	@echo
 	@echo "┏"
 	@echo "┃ NAME(S)"
 	@docker inspect $(SUBMISSION_IMAGE_ID) --format='{{join .RepoTags "\n"}}' | awk '{print "┃ "$$0}'
@@ -88,7 +87,6 @@ ifeq (,$(shell docker images ${OFFICIAL_IMAGE} -q))
 	@echo
 else
 	@echo "$$(tput bold)Available official images:$$(tput sgr0)"
-	@echo
 	@echo "┏"
 	@docker images ${OFFICIAL_IMAGE} | awk '{print "┃ "$$0}'
 	@echo "└"
@@ -100,7 +98,6 @@ ifeq (,$(shell docker images ${LOCAL_IMAGE} -q))
 	@echo
 else
 	@echo "$$(tput bold)Available local images:$$(tput sgr0)"
-	@echo
 	@echo "┏"
 	@docker images ${LOCAL_IMAGE} | awk '{print "┃ "$$0}'
 	@echo "└"

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,9 @@ endif
 TAG := ${CPU_OR_GPU}-latest
 LOCAL_TAG := ${CPU_OR_GPU}-local
 
-OFFICIAL_IMAGE = nasapushback.azurecr.io/nasapushback-competition
-LOCAL_IMAGE = nasapushback-competition
+IMAGE_NAME = nasapushback-competition
+OFFICIAL_IMAGE = nasapushback.azurecr.io/${IMAGE_NAME}
+LOCAL_IMAGE = ${IMAGE_NAME}
 
 # Resolve which image to use in commands. The priority is:
 # 1. User-provided, e.g., SUBMISSION_IMAGE=my-image:gpu-local make test-submission
@@ -68,15 +69,34 @@ ifeq (${SUBMISSION_IMAGE_ID},)
 endif
 
 _echo_image:
-	@echo ${SUBMISSION_IMAGE} hi
-	@echo "$$(tput bold)Available competition images:$$(tput sgr0)"
+	@echo
+ifeq (,$(shell docker images ${OFFICIAL_IMAGE} -q))
+	@echo "$$(tput bold)No official images available locally$$(tput sgr0)"
+	@echo "Run 'make pull' to download the official image."
+	@echo
+else
+	@echo "$$(tput bold)Available official images:$$(tput sgr0)"
 	@echo
 	@echo "┏"
 	@docker images ${OFFICIAL_IMAGE} | awk '{print "┃ "$$0}'
 	@echo "└"
 	@echo
+endif
+ifeq (,$(shell docker images ${LOCAL_IMAGE} -q))
+	@echo "$$(tput bold)No local images available$$(tput sgr0)"
+	@echo "Run 'make build' to build the image."
+	@echo
+else
+	@echo "$$(tput bold)Available local images:$$(tput sgr0)"
+	@echo
+	@echo "┏"
+	@docker images ${LOCAL_IMAGE} | awk '{print "┃ "$$0}'
+	@echo "└"
+	@echo
+endif
 ifeq (,${SUBMISSION_IMAGE_ID})
 	@echo "$$(tput bold)Using image:$$(tput sgr0) ${SUBMISSION_IMAGE} (image does not exist locally)"
+	@echo
 else
 	@echo "$$(tput bold)Using image:$$(tput sgr0) ${SUBMISSION_IMAGE} (${SUBMISSION_IMAGE_ID})"
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,18 @@ endif
 
 _echo_image:
 	@echo
+ifeq (,${SUBMISSION_IMAGE_ID})
+	@echo "$$(tput bold)Using image:$$(tput sgr0) ${SUBMISSION_IMAGE} (image does not exist locally)"
+	@echo
+else
+	@echo "$$(tput bold)Using image:$$(tput sgr0) ${SUBMISSION_IMAGE} (${SUBMISSION_IMAGE_ID})"
+	@echo
+	@echo "┏"
+	@echo "┃ NAME(S)"
+	@docker inspect $(SUBMISSION_IMAGE_ID) --format='{{join .RepoTags "\n"}}' | awk '{print "┃ "$$0}'
+	@echo "└"
+	@echo
+endif
 ifeq (,$(shell docker images ${OFFICIAL_IMAGE} -q))
 	@echo "$$(tput bold)No official images available locally$$(tput sgr0)"
 	@echo "Run 'make pull' to download the official image."
@@ -94,19 +106,6 @@ else
 	@echo "└"
 	@echo
 endif
-ifeq (,${SUBMISSION_IMAGE_ID})
-	@echo "$$(tput bold)Using image:$$(tput sgr0) ${SUBMISSION_IMAGE} (image does not exist locally)"
-	@echo
-else
-	@echo "$$(tput bold)Using image:$$(tput sgr0) ${SUBMISSION_IMAGE} (${SUBMISSION_IMAGE_ID})"
-	@echo
-	@echo "┏"
-	@echo "┃ NAME(S)"
-	@docker inspect $(SUBMISSION_IMAGE_ID) --format='{{join .RepoTags "\n"}}' | awk '{print "┃ "$$0}'
-	@echo "└"
-	@echo
-endif
-
 
 #################################################################################
 # Commands for building the container if you are changing the requirements      #

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ make pack-submission
 make test-submission
 ```
 
+Run `make help` for more information about the available commands as well as information on the official and built images that are available locally.
+
 Here's the process in a bit more detail:
 
 1. First, make sure you have set up the [prerequisites](#prerequisites).


### PR DESCRIPTION
Some improvements to information that the `Makefile` prints out regarding which images are available or used by various commands:

---

<details>
<summary>Fresh install</summary>

```
make help

Using image: nasapushback.azurecr.io/nasapushback-competition:gpu-latest (image does not exist locally)

No official images available locally
Run 'make pull' to download the official image.

No local images available
Run 'make build' to build the image.

Available commands:

build               Builds the container locally 
...
```

---

Already ran `make pull`

```
make help 

Using image: nasapushback.azurecr.io/nasapushback-competition:gpu-latest (8dc4bfc253b6)

┏
┃ NAME(S)
┃ nasapushback.azurecr.io/nasapushback-competition:gpu-latest
└

Available official images:

┏
┃ REPOSITORY                                         TAG          IMAGE ID       CREATED      SIZE
┃ nasapushback.azurecr.io/nasapushback-competition   gpu-latest   8dc4bfc253b6   2 days ago   8.62GB
└

No local images available
Run 'make build' to build the image.

Available commands:

build               Builds the container locally 
...
```
</details>

---

<details><summary>Local image that is identical to official image</summary>

```
make help 

Using image: nasapushback-competition:gpu-latest (8dc4bfc253b6)

┏
┃ NAME(S)
┃ nasapushback-competition:gpu-local
┃ nasapushback.azurecr.io/nasapushback-competition:gpu-latest
└


Available official images:

┏
┃ REPOSITORY                                         TAG          IMAGE ID       CREATED      SIZE
┃ nasapushback.azurecr.io/nasapushback-competition   gpu-latest   8dc4bfc253b6   2 days ago   8.62GB
└

Available local images:

┏
┃ REPOSITORY                 TAG         IMAGE ID       CREATED      SIZE
┃ nasapushback-competition   gpu-local   8dc4bfc253b6   2 days ago   8.62GB
└

Available commands:

build               Builds the container locally 
...
```

</details>

---

<details><summary>Local image that is different from official image</summary>

```
make help 

Using image: nasapushback.azurecr.io/nasapushback-competition:gpu-latest (8dc4bfc253b6)

┏
┃ NAME(S)
┃ nasapushback.azurecr.io/nasapushback-competition:gpu-latest
└

Available official images:

┏
┃ REPOSITORY                                         TAG          IMAGE ID       CREATED      SIZE
┃ nasapushback.azurecr.io/nasapushback-competition   gpu-latest   8dc4bfc253b6   2 days ago   8.62GB
└

Available local images:

┏
┃ REPOSITORY                 TAG         IMAGE ID       CREATED          SIZE
┃ nasapushback-competition   gpu-local   c47a8fd09090   11 minutes ago   8.62GB
└

Available commands:

build               Builds the container locally 
...
```

</details>